### PR TITLE
Add a reference to the CommandsExtension addon

### DIFF
--- a/Discord.Net-Addons/README.md
+++ b/Discord.Net-Addons/README.md
@@ -6,3 +6,4 @@ Here is a collection of addons you can easily port into your Discord.Net Project
 - [Embed Handler](EmbedHandler/)
 - [DiscordClientEvents](DiscordClientEvents/)
 - [Custom Precondition Guide](CustomPreconditions/)
+- [Generate Help Embeds with CommandService extensions](https://github.com/Charly6596/Discord.Addons.CommandsExtension)


### PR DESCRIPTION
Reference a [Discord.Net addon GitHub repository](https://github.com/Charly6596/Discord.Addons.CommandsExtension), wich contains a guide about how to use it
Currently working on that addon Readme.md