### PR TITLE
Add a DSharpPlus guide reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,6 @@ As-well as some Discord.Net Addons you can add to your projects. (DSharpPlus One
 - [Custom Precondition Guide](Discord.Net-Addons/CustomPreconditions)
 - [Generate Help Embeds with CommandService extensions](https://github.com/Charly6596/Discord.Addons.CommandsExtension)
 - [Basic Commands Guide](Discord.Net-Addons/BasicCommands/)
+
+### DSharpPlus Addons & Guides
+- [Using your own entities as command parameters & Converters introduction](https://github.com/Charly6596/DSharpConverterExample)


### PR DESCRIPTION
Add a DSharpPlus guide reference to the README.md file, about how to convert DSharpPlus entities to your own domain entities, also mentions how to create your own converters directly from the user input