### PR TITLE
Add Botconfig Using JSON Example & Minor Updates (Desc)

### DIFF
--- a/BasicBot/src/DataStorage/ConfigDataHandler.cs
+++ b/BasicBot/src/DataStorage/ConfigDataHandler.cs
@@ -41,6 +41,8 @@ namespace BasicBot.DataStorage
                     $"\nPlease fill out the values and restart the bot.");
                 var json = JsonConvert.SerializeObject(GenBlankConfig(), Formatting.Indented);
                 File.WriteAllText(ConfigLocation, json, Encoding.UTF8);
+                Console.ReadLine();
+                Environment.Exit(0);
             }
         }
 

--- a/CommonIssue.json
+++ b/CommonIssue.json
@@ -169,5 +169,15 @@
     ],
     "Description": "Guides you through the several different ways to both find and send Custom Emojis in a Discord.Net or D#+ Bot.",
     "Url": "https://github.com/discord-bot-tutorial/common-issues/tree/master/Issues/CustomEmojis.md"
+  },
+  {
+    "Name": "Bot Config Using JSON",
+	"Img": "https://raw.githubusercontent.com/discord-bot-tutorial/common-issues/master/Images/DataStorage-Json.png",
+    "Aliases": [
+      "BotConfig",
+      "Json"
+    ],
+    "Description": "A simple example of how you can use JSON to store a bot config as-well as fully functioning DataStorage class to Retrieve or Store (Overwrite) a BotConfig.json file.",
+    "Url": "https://github.com/discord-bot-tutorial/common-issues/tree/master/DotNet-Addons/JSON-Storage/BotConfigExample)"
   }
 ]

--- a/DotNet-Addons/JSON-Storage/BotConfigExample/BotConfig.cs
+++ b/DotNet-Addons/JSON-Storage/BotConfigExample/BotConfig.cs
@@ -1,0 +1,6 @@
+public class BotConfig
+{
+    public string Token { get; set; }
+    public string GameStatus { get; set; }
+    public string Prefix { get; set }
+}

--- a/DotNet-Addons/JSON-Storage/BotConfigExample/DataStorage.cs
+++ b/DotNet-Addons/JSON-Storage/BotConfigExample/DataStorage.cs
@@ -1,0 +1,57 @@
+
+public BotConfig GetBotConfig(string filepath)
+    => FetchOrCreateBotConfig(filepath);
+
+//Public Method can be used to overwrite the botconfig if required.
+public void SaveBotConfig(BotConfig config, string filepath)
+    => WriteBotConfig(config, filepath);
+
+//Simple Method to check if the config.json exists.
+private bool Exists(string filepath)
+{
+    if(File.Exists(filepath))
+        return true;
+    return false;
+}
+
+//Method to either fetch the BotConfig or create a new blank config for you to fill in.
+//Exits the application if a config doesn't already exist.
+private BotConfig FetchOrCreateBotConfig(string filepath)
+{
+    if (Exists(filepath))
+    {
+        var rawData - GetRawData(filepath);
+        return JsonConvert.DeserializeObject<BotConfig>(rawData);
+    }
+    Console.WriteLine("New Config.json found." + 
+                      $"\nA new One has been created at: {Directory.GetCurrentDirectory()}");
+
+    var newConfig = GenNewBotConfig();
+    WriteBotConfig(newConfig, filepath);
+    Console.ReadLine();
+    Environment.Exit(0);
+}
+
+//Read the config file and return it as a string.
+private string GetRawData(string filepath)
+    => File.ReadAllText(filepath);
+
+//Write the config data to the config.json.
+private void WriteBotConfig(BotConfig config, string filepath)
+{
+    var rawData = SerializeBotConfig(config)
+    File.WriteAllText(filepath, rawData, Encoding.UTF8);
+}
+
+// Serialize The BotConfig Object into a string ready to write to the file.
+private string SerializeBotConfig(BotConfig config)
+    => JsonConvert.SerializeObject(config, Formatting.Indented);
+
+//Generate a config template for you to fill in.
+private BotConfig GenNewBotConfig()
+    => new BotConfig
+    {
+        Token = "CHANGE ME TO YOUR TOKEN",
+        GameStatus = "CHANGE ME TO A STATUS",
+        Prefix = "!" 
+    };

--- a/DotNet-Addons/JSON-Storage/BotConfigExample/README.md
+++ b/DotNet-Addons/JSON-Storage/BotConfigExample/README.md
@@ -1,0 +1,19 @@
+<p align="center">
+    <img src="../../../Images/DataStorage-Json.png">
+</p>
+
+# BotConfig with JSON DataStorage
+
+## What is it
+
+This is a simple example of how you can use JSON to store a bot config as-well as fully functioning DataStorage class to Retrieve or Store (Overwrite) a BotConfig.json file.
+
+**NOTE:** This is not meant to be a copy/paste example. While this will work, it's intention is to guide you on how you can create your own.
+
+---
+
+If none of the above example covers your current issue, jump into our discord (Link Below) and ask for help. If you don't want to use Discord, you can use the link [HERE](https://github.com/discord-bot-tutorial/common-issues/issues) to open a new issue directly from this github repo, this will send a notification to our discord server where one of the many Helpers we have can get back to you.
+
+Author: Draxis#0359
+
+Discord:  [Discord-BOT-Tutorial Server](https://discord.gg/cGhEZuk)

--- a/DotNet-Addons/JSON-Storage/BotConfigExample/config.json
+++ b/DotNet-Addons/JSON-Storage/BotConfigExample/config.json
@@ -1,0 +1,5 @@
+{
+    "Token": "YourToken",
+    "GameStatus": "Your Bots Game Status",
+    "Prefix": "YourPrefix"
+}

--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ As-well as some Discord.Net Addons you can add to your projects. (DSharpPlus One
 
 - [Random Picker Using LINQ](DotNet-Addons/PickRandomLINQ.cs)
 - [Storing Data With JSON](DotNet-Addons/JSON-Storage/)
+  - [Example BotConfig](DotNet-Addons/JSON-Storage/BotConfigExample)


### PR DESCRIPTION
Add
* Botconfig using Json example
* Fully functioning DataHandler for BotConfig
* README.md explaining what it is.

Update
* Main README.md to include new additon.
* Common-Issues.json to unclude new additon.

Fix
* BasicBot DataHandler, Now closes if config.json isn't found after creating a new one.
  * This stop the bot throwing an exception for the token being incorrect when a new config is created.